### PR TITLE
extend code to allow missing variables when marked with omitempty

### DIFF
--- a/.env.sample3
+++ b/.env.sample3
@@ -1,0 +1,6 @@
+MY_APP_EMAIL=someemail@someprovider.org
+#MY_APP_PASSWORD=password
+MY_APP_PASSWORD=password2
+MY_APP_ENDPOINT=some-endpoint
+MY_APP_URL=https://some.exmpale.org/foo?token=bar
+MY_APP_OPTIONAL=optional

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A minimalistic approach to [spf13/viper](https://github.com/spf13/viper).
 - [No dependencies](go.mod)
 
 Only string fields are supported. 
-
+Allows missing env variables when marked with "omitempty"
 ## Usage
 
 ```go
@@ -29,6 +29,7 @@ type Config struct {
         someOtherProperty string
 	}
 	Endpoint string `env:"MY_APP_ENDPOINT"`
+  AppUrl string `env:MY_APP_URL,omitempty`
 }
 
 func main() {


### PR DESCRIPTION
- implemented feature in _tinyviper.go_ file
- extended test _TestConfigOverride_ to check that there is no "missing variable" error when "omitempty" specified (it checks that the value of the field is empty string)
- added test to check if the value is still loaded when variable is defined despite "omitempty" 
- test that checks for "missing variable" error when no "omitempty" is specified and the variable is not defined